### PR TITLE
Footer Link updated to redirect to GDSC DEU site

### DIFF
--- a/pages/components/Footer.js
+++ b/pages/components/Footer.js
@@ -21,7 +21,7 @@ export const Footer = (props) => {
                     </ul>
                 </div>
                 <hr className="my-4 border-gray-200 sm:mx-auto dark:border-gray-700 lg:my-6" />
-                <span className="block text-sm sm:text-center text-gray-800">© 2023 <a href="#" className="hover:underline text-semibold hover:text-blue-700">GDSC GEU</a>. All Rights Reserved.</span>
+                <span className="block text-sm sm:text-center text-gray-800">© 2023 <a href="https://dscgeu.vercel.app/" target="_blank" className="hover:underline text-semibold hover:text-blue-700">GDSC GEU</a>. All Rights Reserved.</span>
             </div>
         </footer>
   )


### PR DESCRIPTION
This is PR which fixes `issue #14 `
This issue #14 was about linking the hyperlink in the footer of the website so that it redirects to https://dscgeu.vercel.app/
PS: `I have used target="_blank" too for better user experience and flow`